### PR TITLE
[FEATURES] ActivateOpenWindow, OpenWindowDetection, ChildLockEnabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you like my work, please feel free to provide a personal donation
 | tado.[x].[yyyyyy].Rooms.[z].devices.[RUaaaaaaaaaa].offset.offsetCelsius | Temperature offset |
 | tado.[x].[yyyyyy].Rooms.[z].devices.[RUaaaaaaaaaa].childLockEnabled | Child Lock on/off |
 | tado.[x].[yyyyyy].Rooms.[z].timeTables.tt_id | Select active time table |
-| tado.[x].[yyyyyy].Rooms.[z].openWindowDetection.enabled | Enable/Disable open window detection on thermostat |
+| tado.[x].[yyyyyy].Rooms.[z].openWindowDetection.openWindowDetectionEnabled | Enable/Disable open window detection on thermostat |
 | tado.[x].[yyyyyy].Rooms.[z].openWindowDetection.timeoutInSeconds | Timeout how long thermostats are turned off when an open window is detected |
 | tado.[x].[yyyyyy].Rooms.[z].activateOpenWindow | Switch thermostats off when an open window is detected (only works if the thermostat detects an open window) | 
 | tado.[x].[yyyyyy].Home.state.presence | Set HOME or AWAY mode |

--- a/README.md
+++ b/README.md
@@ -42,6 +42,37 @@ If you like my work, please feel free to provide a personal donation
 | tado.[x].[yyyyyy].Rooms.[z].setting.horizontalSwing | Horizontal swing (only AC devices with V3 and olderversions) |
 
 
+## Changelog
+<!--
+    Placeholder for the next version (at the beginning of the line):
+    ### __WORK IN PROGRESS__
+-->
+### 0.3.14 (2022-01-21)
+* (HGlab01) Improve hotwater handling
+* (HGlab01) Improve AC Control v3 devices 
+* (HGlab01) Support swing ON/OFF for AC v3 devices
+
+### 0.3.13 (2022-01-03)
+* (HGlab01) Optimize internet-check by using isOnline-library
+* (HGlab01) Support Smart AC Control V3+ (issue #403)
+* (HGlab01) Offset temperature rounding to max. 2 digits
+
+### 0.3.12 (2021-11-25)
+* (HGlab01) support attribute 'showScheduleSetup'
+* (HGlab01) fix HOT_WATER device issue with temperature
+* (HGlab01) Bump iobroker-jsonexplorer to 0.1.8 (avoids re-sending same missing-attribeute info to Sentry after restart)
+
+### 0.3.11 (2021-11-19)
+* (HGlab01) support attributes 'showSwitchToAutoGeofencingButton', 'showHomePresenceSwitchButton', 'scheduleIsDefault' and 'additionalConsents'
+* (HGlab01) enhance error messages if API-call fails
+* (HGlab01) next time block fails (one reason for 422 error) if time blocks are not defined - fixed now
+* (HGlab01) set HOME/AWAY is now suported by using state tado.x.yyyyyy.Home.state.presence
+* (HGlab01) offset range -9.99/+10 validated
+* (HGlab01) add masterswitch for power on/off (tado.[x].[yyyyyy].Home.masterswitch)
+* (HGlab01) reduce logs in info-mode
+* (HGlab01) AC temperature range fixed
+* (HGlab01) Bump iobroker-jsonexplorer to 0.1.7
+
 ### 0.3.10 (2021-10-29)
 * (HGlab01) API calls (except read) are queued and send one after the other
 * (HGlab01) unhandled errors are now handled

--- a/README.md
+++ b/README.md
@@ -20,57 +20,27 @@ If you like my work, please feel free to provide a personal donation
 [![Donate](https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/admin/button.png)](http://paypal.me/DutchmanNL)
 
 ## Things you can steer
-| State                                                                   | Description                                                                                                  |
-|-------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
-| tado.[x].[yyyyyy].Rooms.[z].setting.power                               | Turn device on/off                                                                                           |
-| tado.[x].[yyyyyy].Rooms.[z].setting.temperature.celsius                 | Define temperature                                                                                           |
-| tado.[x].[yyyyyy].Rooms.[z].overlayClearZone                            | Switch to automatic mode                                                                                     |
-| tado.[x].[yyyyyy].Rooms.[z].overlay.termination.typeSkillBasedApp       | Set time table mode                                                                                          |
-| tado.[x].[yyyyyy].Rooms.[z].overlay.termination.durationInSeconds       | Set how long the time table mode shall apply                                                                 |
-| tado.[x].[yyyyyy].Rooms.[z].devices.[RUaaaaaaaaaa].offset.offsetCelsius | Temperature offset                                                                                           |
-| tado.[x].[yyyyyy].Rooms.[z].devices.[RUaaaaaaaaaa].childLockEnabled     | Child Lock on/off                                                                                            |
-| tado.[x].[yyyyyy].Rooms.[z].timeTables.tt_id                            | Select active time table                                                                                     |
-| tado.[x].[yyyyyy].Rooms.[z].openWindowDetection.enabled                 | Enable/Disable open window detection on thermostat                                                           |
-| tado.[x].[yyyyyy].Rooms.[z].openWindowDetection.timeoutInSeconds        | Timeout how long thermostats are turned off when an open window is detected                                  |
-| tado.[x].[yyyyyy].Rooms.[z].activateOpenWindow                          | Switch thermostats off when an open window is detected (only works if the thermostatdetects an open window) |
-| tado.[x].[yyyyyy].Home.state.presence                                   | Set HOME or AWAY mode                                                                                        |
-| tado.[x].[yyyyyy].Home.masterswitch                                     | Turn all devices on/off                                                                                      |
-| tado.[x].[yyyyyy].Rooms.[z].setting.mode                                | AC mode (only AC devices)                                                                                    |
-| tado.[x].[yyyyyy].Rooms.[z].setting.fanspeed                            | Fanspeed (only AC devices with V3 and older versions)                                                        |
-| tado.[x].[yyyyyy].Rooms.[z].setting.fanLebel                            | Fanlebel (only AC devices with V3+ version)                                                                  |
-| tado.[x].[yyyyyy].Rooms.[z].setting.verticalSwing                       | Vertical swing (only AC devices with V3+ version)                                                            |
-| tado.[x].[yyyyyy].Rooms.[z].setting.horizontalSwing                     | Horizontal swing (only AC devices with V3 and olderversions)                                                 |
+| State | Description |
+| ----- | ----------- |
+| tado.[x].[yyyyyy].Rooms.[z].setting.power | Turn device on/off |
+| tado.[x].[yyyyyy].Rooms.[z].setting.temperature.celsius | Define temperature |
+| tado.[x].[yyyyyy].Rooms.[z].overlayClearZone | Switch to automatic mode |
+| tado.[x].[yyyyyy].Rooms.[z].overlay.termination.typeSkillBasedApp | Set time table mode |
+| tado.[x].[yyyyyy].Rooms.[z].overlay.termination.durationInSeconds | Set how long the time table mode shall apply |
+| tado.[x].[yyyyyy].Rooms.[z].devices.[RUaaaaaaaaaa].offset.offsetCelsius | Temperature offset |
+| tado.[x].[yyyyyy].Rooms.[z].devices.[RUaaaaaaaaaa].childLockEnabled | Child Lock on/off |
+| tado.[x].[yyyyyy].Rooms.[z].timeTables.tt_id | Select active time table |
+| tado.[x].[yyyyyy].Rooms.[z].openWindowDetection.enabled | Enable/Disable open window detection on thermostat |
+| tado.[x].[yyyyyy].Rooms.[z].openWindowDetection.timeoutInSeconds | Timeout how long thermostats are turned off when an open window is detected |
+| tado.[x].[yyyyyy].Rooms.[z].activateOpenWindow | Switch thermostats off when an open window is detected (only works if the thermostat detects an open window) | 
+| tado.[x].[yyyyyy].Home.state.presence | Set HOME or AWAY mode |
+| tado.[x].[yyyyyy].Home.masterswitch | Turn all devices on/off |
+| tado.[x].[yyyyyy].Rooms.[z].setting.mode | AC mode (only AC devices) |
+| tado.[x].[yyyyyy].Rooms.[z].setting.fanspeed | Fanspeed (only AC devices with V3 and older versions) |
+| tado.[x].[yyyyyy].Rooms.[z].setting.fanLebel | Fanlebel (only AC devices with V3+ version) |
+| tado.[x].[yyyyyy].Rooms.[z].setting.verticalSwing | Vertical swing (only AC devices with V3+ version) |
+| tado.[x].[yyyyyy].Rooms.[z].setting.horizontalSwing | Horizontal swing (only AC devices with V3 and olderversions) |
 
-## Changelog
-<!--
-    Placeholder for the next version (at the beginning of the line):
-    ### __WORK IN PROGRESS__
--->
-### 0.3.14 (2022-01-21)
-* (HGlab01) Improve hotwater handling
-* (HGlab01) Improve AC Control v3 devices 
-* (HGlab01) Support swing ON/OFF for AC v3 devices
-
-### 0.3.13 (2022-01-03)
-* (HGlab01) Optimize internet-check by using isOnline-library
-* (HGlab01) Support Smart AC Control V3+ (issue #403)
-* (HGlab01) Offset temperature rounding to max. 2 digits
-
-### 0.3.12 (2021-11-25)
-* (HGlab01) support attribute 'showScheduleSetup'
-* (HGlab01) fix HOT_WATER device issue with temperature
-* (HGlab01) Bump iobroker-jsonexplorer to 0.1.8 (avoids re-sending same missing-attribeute info to Sentry after restart)
-
-### 0.3.11 (2021-11-19)
-* (HGlab01) support attributes 'showSwitchToAutoGeofencingButton', 'showHomePresenceSwitchButton', 'scheduleIsDefault' and 'additionalConsents'
-* (HGlab01) enhance error messages if API-call fails
-* (HGlab01) next time block fails (one reason for 422 error) if time blocks are not defined - fixed now
-* (HGlab01) set HOME/AWAY is now suported by using state tado.x.yyyyyy.Home.state.presence
-* (HGlab01) offset range -9.99/+10 validated
-* (HGlab01) add masterswitch for power on/off (tado.[x].[yyyyyy].Home.masterswitch)
-* (HGlab01) reduce logs in info-mode
-* (HGlab01) AC temperature range fixed
-* (HGlab01) Bump iobroker-jsonexplorer to 0.1.7
 
 ### 0.3.10 (2021-10-29)
 * (HGlab01) API calls (except read) are queued and send one after the other

--- a/README.md
+++ b/README.md
@@ -20,22 +20,26 @@ If you like my work, please feel free to provide a personal donation
 [![Donate](https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/admin/button.png)](http://paypal.me/DutchmanNL)
 
 ## Things you can steer
-| State | Description |
-| ----- | ----------- |
-| tado.[x].[yyyyyy].Rooms.[z].setting.power | Turn device on/off |
-| tado.[x].[yyyyyy].Rooms.[z].setting.temperature.celsius | Define temperature |
-| tado.[x].[yyyyyy].Rooms.[z].overlayClearZone | Switch to automatic mode |
-| tado.[x].[yyyyyy].Rooms.[z].overlay.termination.typeSkillBasedApp | Set time table mode |
-| tado.[x].[yyyyyy].Rooms.[z].overlay.termination.durationInSeconds | Set how long the time table mode shall apply |
-| tado.[x].[yyyyyy].Rooms.[z].devices.[RUaaaaaaaaaa].offset.offsetCelsius | Temperature offset |
-| tado.[x].[yyyyyy].Rooms.[z].timeTables.tt_id | Select active time table |
-| tado.[x].[yyyyyy].Home.state.presence | Set HOME or AWAY mode |
-| tado.[x].[yyyyyy].Home.masterswitch | Turn all devices on/off |
-| tado.[x].[yyyyyy].Rooms.[z].setting.mode | AC mode (only AC devices) |
-| tado.[x].[yyyyyy].Rooms.[z].setting.fanspeed | Fanspeed (only AC devices with V3 and older versions) |
-| tado.[x].[yyyyyy].Rooms.[z].setting.fanLebel | Fanlebel (only AC devices with V3+ version) |
-| tado.[x].[yyyyyy].Rooms.[z].setting.verticalSwing | Vertical swing (only AC devices with V3+ version) |
-| tado.[x].[yyyyyy].Rooms.[z].setting.horizontalSwing | Horizontal swing (only AC devices with V3 and olderversions) |
+| State                                                                   | Description                                                                                                   |
+|-------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| tado.[x].[yyyyyy].Rooms.[z].setting.power                               | Turn device on/off                                                                                            |
+| tado.[x].[yyyyyy].Rooms.[z].setting.temperature.celsius                 | Define temperature                                                                                            |
+| tado.[x].[yyyyyy].Rooms.[z].overlayClearZone                            | Switch to automatic mode                                                                                      |
+| tado.[x].[yyyyyy].Rooms.[z].overlay.termination.typeSkillBasedApp       | Set time table mode                                                                                           |
+| tado.[x].[yyyyyy].Rooms.[z].overlay.termination.durationInSeconds       | Set how long the time table mode shall apply                                                                  |
+| tado.[x].[yyyyyy].Rooms.[z].devices.[RUaaaaaaaaaa].offset.offsetCelsius | Temperature offset                                                                                            |
+| tado.[x].[yyyyyy].Rooms.[z].devices.[RUaaaaaaaaaa].childLockEnabled     | Child Lock on/off                                                                                             |
+| tado.[x].[yyyyyy].Rooms.[z].timeTables.tt_id                            | Select active time table                                                                                      |
+| tado.[x].[yyyyyy].Rooms.[z].openWindowDetection.enabled                 | Enable/Disable open window detection on thermostate                                                           |
+| tado.[x].[yyyyyy].Rooms.[z].openWindowDetection.timeoutInSeconds        | Timeout how long thermostats are turned off when an open window is detected                                   |
+| tado.[x].[yyyyyy].Rooms.[z].activateOpenWindow                          | Switch thermostats off when an open window is detected (only works if the thermostate detects an open window) |
+| tado.[x].[yyyyyy].Home.state.presence                                   | Set HOME or AWAY mode                                                                                         |
+| tado.[x].[yyyyyy].Home.masterswitch                                     | Turn all devices on/off                                                                                       |
+| tado.[x].[yyyyyy].Rooms.[z].setting.mode                                | AC mode (only AC devices)                                                                                     |
+| tado.[x].[yyyyyy].Rooms.[z].setting.fanspeed                            | Fanspeed (only AC devices with V3 and older versions)                                                         |
+| tado.[x].[yyyyyy].Rooms.[z].setting.fanLebel                            | Fanlebel (only AC devices with V3+ version)                                                                   |
+| tado.[x].[yyyyyy].Rooms.[z].setting.verticalSwing                       | Vertical swing (only AC devices with V3+ version)                                                             |
+| tado.[x].[yyyyyy].Rooms.[z].setting.horizontalSwing                     | Horizontal swing (only AC devices with V3 and olderversions)                                                  |
 
 ## Changelog
 <!--

--- a/README.md
+++ b/README.md
@@ -20,26 +20,26 @@ If you like my work, please feel free to provide a personal donation
 [![Donate](https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/admin/button.png)](http://paypal.me/DutchmanNL)
 
 ## Things you can steer
-| State                                                                   | Description                                                                                                   |
-|-------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
-| tado.[x].[yyyyyy].Rooms.[z].setting.power                               | Turn device on/off                                                                                            |
-| tado.[x].[yyyyyy].Rooms.[z].setting.temperature.celsius                 | Define temperature                                                                                            |
-| tado.[x].[yyyyyy].Rooms.[z].overlayClearZone                            | Switch to automatic mode                                                                                      |
-| tado.[x].[yyyyyy].Rooms.[z].overlay.termination.typeSkillBasedApp       | Set time table mode                                                                                           |
-| tado.[x].[yyyyyy].Rooms.[z].overlay.termination.durationInSeconds       | Set how long the time table mode shall apply                                                                  |
-| tado.[x].[yyyyyy].Rooms.[z].devices.[RUaaaaaaaaaa].offset.offsetCelsius | Temperature offset                                                                                            |
-| tado.[x].[yyyyyy].Rooms.[z].devices.[RUaaaaaaaaaa].childLockEnabled     | Child Lock on/off                                                                                             |
-| tado.[x].[yyyyyy].Rooms.[z].timeTables.tt_id                            | Select active time table                                                                                      |
-| tado.[x].[yyyyyy].Rooms.[z].openWindowDetection.enabled                 | Enable/Disable open window detection on thermostate                                                           |
-| tado.[x].[yyyyyy].Rooms.[z].openWindowDetection.timeoutInSeconds        | Timeout how long thermostats are turned off when an open window is detected                                   |
-| tado.[x].[yyyyyy].Rooms.[z].activateOpenWindow                          | Switch thermostats off when an open window is detected (only works if the thermostate detects an open window) |
-| tado.[x].[yyyyyy].Home.state.presence                                   | Set HOME or AWAY mode                                                                                         |
-| tado.[x].[yyyyyy].Home.masterswitch                                     | Turn all devices on/off                                                                                       |
-| tado.[x].[yyyyyy].Rooms.[z].setting.mode                                | AC mode (only AC devices)                                                                                     |
-| tado.[x].[yyyyyy].Rooms.[z].setting.fanspeed                            | Fanspeed (only AC devices with V3 and older versions)                                                         |
-| tado.[x].[yyyyyy].Rooms.[z].setting.fanLebel                            | Fanlebel (only AC devices with V3+ version)                                                                   |
-| tado.[x].[yyyyyy].Rooms.[z].setting.verticalSwing                       | Vertical swing (only AC devices with V3+ version)                                                             |
-| tado.[x].[yyyyyy].Rooms.[z].setting.horizontalSwing                     | Horizontal swing (only AC devices with V3 and olderversions)                                                  |
+| State                                                                   | Description                                                                                                  |
+|-------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| tado.[x].[yyyyyy].Rooms.[z].setting.power                               | Turn device on/off                                                                                           |
+| tado.[x].[yyyyyy].Rooms.[z].setting.temperature.celsius                 | Define temperature                                                                                           |
+| tado.[x].[yyyyyy].Rooms.[z].overlayClearZone                            | Switch to automatic mode                                                                                     |
+| tado.[x].[yyyyyy].Rooms.[z].overlay.termination.typeSkillBasedApp       | Set time table mode                                                                                          |
+| tado.[x].[yyyyyy].Rooms.[z].overlay.termination.durationInSeconds       | Set how long the time table mode shall apply                                                                 |
+| tado.[x].[yyyyyy].Rooms.[z].devices.[RUaaaaaaaaaa].offset.offsetCelsius | Temperature offset                                                                                           |
+| tado.[x].[yyyyyy].Rooms.[z].devices.[RUaaaaaaaaaa].childLockEnabled     | Child Lock on/off                                                                                            |
+| tado.[x].[yyyyyy].Rooms.[z].timeTables.tt_id                            | Select active time table                                                                                     |
+| tado.[x].[yyyyyy].Rooms.[z].openWindowDetection.enabled                 | Enable/Disable open window detection on thermostat                                                           |
+| tado.[x].[yyyyyy].Rooms.[z].openWindowDetection.timeoutInSeconds        | Timeout how long thermostats are turned off when an open window is detected                                  |
+| tado.[x].[yyyyyy].Rooms.[z].activateOpenWindow                          | Switch thermostats off when an open window is detected (only works if the thermostatdetects an open window) |
+| tado.[x].[yyyyyy].Home.state.presence                                   | Set HOME or AWAY mode                                                                                        |
+| tado.[x].[yyyyyy].Home.masterswitch                                     | Turn all devices on/off                                                                                      |
+| tado.[x].[yyyyyy].Rooms.[z].setting.mode                                | AC mode (only AC devices)                                                                                    |
+| tado.[x].[yyyyyy].Rooms.[z].setting.fanspeed                            | Fanspeed (only AC devices with V3 and older versions)                                                        |
+| tado.[x].[yyyyyy].Rooms.[z].setting.fanLebel                            | Fanlebel (only AC devices with V3+ version)                                                                  |
+| tado.[x].[yyyyyy].Rooms.[z].setting.verticalSwing                       | Vertical swing (only AC devices with V3+ version)                                                            |
+| tado.[x].[yyyyyy].Rooms.[z].setting.horizontalSwing                     | Horizontal swing (only AC devices with V3 and olderversions)                                                 |
 
 ## Changelog
 <!--

--- a/lib/state_attr.js
+++ b/lib/state_attr.js
@@ -124,7 +124,7 @@ const state_attrb = {
 	},
 	'activateOpenWindow': {
 		'name': 'Activate Open Window',
-		'role': 'state',
+		'role': 'button',
 		'type': 'boolean',
 		'write': true
 	},

--- a/lib/state_attr.js
+++ b/lib/state_attr.js
@@ -125,7 +125,7 @@ const state_attrb = {
 	'activateOpenWindow': {
 		'name': 'Activate Open Window',
 		'role': 'state',
-		'type': 'string',
+		'type': 'boolean',
 		'write': true
 	},
 	'dazzleMode': {

--- a/lib/state_attr.js
+++ b/lib/state_attr.js
@@ -122,6 +122,12 @@ const state_attrb = {
 		'role': 'state',
 		'type': 'boolean'
 	},
+	'activateOpenWindow': {
+		'name': 'Activate Open Window',
+		'role': 'state'
+		'type': 'string',
+		'write': true
+	},
 	'dazzleMode': {
 		'name': 'Dazzle Mode',
 		'role': 'state',

--- a/lib/state_attr.js
+++ b/lib/state_attr.js
@@ -124,7 +124,7 @@ const state_attrb = {
 	},
 	'activateOpenWindow': {
 		'name': 'Activate Open Window',
-		'role': 'state'
+		'role': 'state',
 		'type': 'string',
 		'write': true
 	},

--- a/lib/state_attr.js
+++ b/lib/state_attr.js
@@ -769,6 +769,12 @@ const state_attrb = {
 		'unit': 's',
 		'write': true
 	},
+	'openWindowDetectionEnabled': {
+		'name': 'Open window detection enabled',
+		'role': 'state',
+		'type': 'boolean',
+		'write': true
+	},
 	'timestamp': {
 		'name': 'Timestamp',
 		'role': 'value.time',

--- a/lib/state_attr.js
+++ b/lib/state_attr.js
@@ -65,7 +65,8 @@ const state_attrb = {
 	'childLockEnabled': {
 		'name': 'Child-Lock enabled',
 		'role': 'state',
-		'type': 'boolean'
+		'type': 'boolean',
+		'write': true
 	},
 	'christmasModeEnabled': {
 		'name': 'Christmas mode enabled',

--- a/lib/state_attr.js
+++ b/lib/state_attr.js
@@ -765,7 +765,8 @@ const state_attrb = {
 		'name': 'TimeoutInSeconds',
 		'role': 'state',
 		'type': 'number',
-		'unit': 's'
+		'unit': 's',
+		'write': true
 	},
 	'timestamp': {
 		'name': 'Timestamp',

--- a/main.js
+++ b/main.js
@@ -1135,7 +1135,7 @@ class Tado extends utils.Adapter {
 		}
 		if (method != 'get') {
 			this.apiCallinExecution = true;
-			console.log(`Body "${JSON.stringify(data)}" for API call "${url}"`);
+			this.log.debug(`Body "${JSON.stringify(data)}" for API call "${url}"`);
 		}
 		return new Promise((resolve, reject) => {
 			if (this.accessToken) {

--- a/main.js
+++ b/main.js
@@ -267,7 +267,7 @@ class Tado extends utils.Adapter {
 								const activateOpenWindow = state;
 								let set_activateOpenWindow = (activateOpenWindow == null || activateOpenWindow == undefined || activateOpenWindow.val == null || activateOpenWindow.val == '') ? 'unknown' : activateOpenWindow.val.toString().toUpperCase();
 								if (set_activateOpenWindow !== true) {
-									this.log.debug(`Expecting 'true' as value for 'Activate Open Window'`);
+									this.log.debug(`Expecting 'true' as value for 'Activate Open Window'. Got '${JSON.stringify(set_activateOpenWindow)}' (state was '${JSON.stringify(activateOpenWindow)}')`);
 									break;
 								}
 								this.log.debug(`Activate Open Window for room '${zone_id}' in home '${home_id}'`);

--- a/main.js
+++ b/main.js
@@ -720,7 +720,7 @@ class Tado extends utils.Adapter {
 	 * @param {boolean} enabled
 	 */
 	async setChildLock(home_id, zone_id, device_id, enabled) {
-		let url = `/api/v2/homes/${home_id}/devices/${device_id}/childLock`;
+		let url = `/api/v2/devices/${device_id}/childLock`;
 		if (await isOnline() == false) {
 			throw new Error('No internet connection detected!');
 		}

--- a/main.js
+++ b/main.js
@@ -267,7 +267,7 @@ class Tado extends utils.Adapter {
 								this.log.debug(state);
 								const activateOpenWindow = state;
 								let set_activateOpenWindow = (activateOpenWindow == null || activateOpenWindow == undefined || activateOpenWindow.val == null || activateOpenWindow.val == '') ? 'unknown' : activateOpenWindow.val;
-								this.log.debug(set_activateOpenWindow);
+								this.log.debug(set_activateOpenWindow, set_activateOpenWindow == true);
 								if (set_activateOpenWindow == true) {
 									this.log.debug(`Activate Open Window for room '${zone_id}' in home '${home_id}'`);
 									await this.activateOpenWindow(home_id, zone_id);

--- a/main.js
+++ b/main.js
@@ -846,6 +846,7 @@ class Tado extends utils.Adapter {
 			ZonesState_data.setting.temperature = {};
 			ZonesState_data.setting.temperature.celsius = null;
 		}
+		ZonesState_data.activateOpenWindow = null;
 		this.DoWriteJsonRespons(HomeId, 'Stage_09_ZoneStates_data_' + ZoneId, ZonesState_data);
 		ZonesState_data.overlayClearZone = false;
 		JsonExplorer.TraverseJson(ZonesState_data, HomeId + '.Rooms.' + ZoneId, true, true, 0, 2);

--- a/main.js
+++ b/main.js
@@ -264,8 +264,10 @@ class Tado extends utils.Adapter {
 								break;
 							
 							case ('activateOpenWindow'):
+								this.log.debug(state);
 								const activateOpenWindow = state;
 								let set_activateOpenWindow = (activateOpenWindow == null || activateOpenWindow == undefined || activateOpenWindow.val == null || activateOpenWindow.val == '') ? 'unknown' : activateOpenWindow.val;
+								this.log.debug(set_activateOpenWindow);
 								if (set_activateOpenWindow == true) {
 									this.log.debug(`Activate Open Window for room '${zone_id}' in home '${home_id}'`);
 									await this.activateOpenWindow(home_id, zone_id);

--- a/main.js
+++ b/main.js
@@ -264,10 +264,8 @@ class Tado extends utils.Adapter {
 								break;
 							
 							case ('activateOpenWindow'):
-								this.log.debug(state);
 								const activateOpenWindow = state;
 								let set_activateOpenWindow = (activateOpenWindow == null || activateOpenWindow == undefined || activateOpenWindow.val == null || activateOpenWindow.val == '') ? 'unknown' : activateOpenWindow.val;
-								this.log.debug(set_activateOpenWindow, set_activateOpenWindow == true);
 								if (set_activateOpenWindow == true) {
 									this.log.debug(`Activate Open Window for room '${zone_id}' in home '${home_id}'`);
 									await this.activateOpenWindow(home_id, zone_id);

--- a/main.js
+++ b/main.js
@@ -266,14 +266,14 @@ class Tado extends utils.Adapter {
 							case ('activateOpenWindow'):
 								const activateOpenWindow = state;
 								let set_activateOpenWindow = (activateOpenWindow == null || activateOpenWindow == undefined || activateOpenWindow.val == null || activateOpenWindow.val == '') ? 'unknown' : activateOpenWindow.val;
-								if (set_activateOpenWindow !== true) {
+								if (set_activateOpenWindow == true) {
+									this.log.debug(`Activate Open Window for room '${zone_id}' in home '${home_id}'`);
+									await this.activateOpenWindow(home_id, zone_id);
+									await this.sleep(1000);
+									this.setStateAsync(`${home_id}.Rooms.${zone_id}.activateOpenWindow`, null, true);
+								} else {
 									this.log.debug(`Expecting 'true' as value for 'Activate Open Window'. Got '${JSON.stringify(set_activateOpenWindow)}'`);
-									break;
 								}
-								this.log.debug(`Activate Open Window for room '${zone_id}' in home '${home_id}'`);
-								await this.activateOpenWindow(home_id, zone_id);
-								await this.sleep(1000);
-								this.setStateAsync(`${home_id}.Rooms.${zone_id}.activateOpenWindow`, null, true);
 								break;
 							default:
 						}

--- a/main.js
+++ b/main.js
@@ -939,6 +939,9 @@ class Tado extends utils.Adapter {
 					}
 				}
 			}
+			// Change `enabled` to `openWindowDetectionEnabled`
+			this.Zones_data[j].openWindowDetection.openWindowDetectionEnabled = this.Zones_data[j].openWindowDetection.enabled;
+			delete this.Zones_data[j].openWindowDetection.enabled;
 		}
 
 		JsonExplorer.TraverseJson(this.Zones_data, `${HomeId}.Rooms`, true, true, 0, 0);
@@ -959,8 +962,6 @@ class Tado extends utils.Adapter {
 			ZonesState_data.setting.temperature = {};
 			ZonesState_data.setting.temperature.celsius = null;
 		}
-		ZonesState_data.openWindowDetection.openWindowDetectionEnabled = ZonesState_data.openWindowDetection.enabled;
-		delete ZonesState_data.openWindowDetection.enabled;
 		this.DoWriteJsonRespons(HomeId, 'Stage_09_ZoneStates_data_' + ZoneId, ZonesState_data);
 		ZonesState_data.overlayClearZone = false;
 		ZonesState_data.activateOpenWindow = false;

--- a/main.js
+++ b/main.js
@@ -270,9 +270,7 @@ class Tado extends utils.Adapter {
 									this.log.debug(`Activate Open Window for room '${zone_id}' in home '${home_id}'`);
 									await this.activateOpenWindow(home_id, zone_id);
 									await this.sleep(1000);
-									this.setStateAsync(`${home_id}.Rooms.${zone_id}.activateOpenWindow`, null, true);
-								} else {
-									this.log.debug(`Expecting 'true' as value for 'Activate Open Window'. Got '${JSON.stringify(set_activateOpenWindow)}'`);
+									this.setStateAsync(`${home_id}.Rooms.${zone_id}.activateOpenWindow`, false, true);
 								}
 								break;
 							default:
@@ -924,9 +922,9 @@ class Tado extends utils.Adapter {
 			ZonesState_data.setting.temperature = {};
 			ZonesState_data.setting.temperature.celsius = null;
 		}
-		ZonesState_data.activateOpenWindow = null;
 		this.DoWriteJsonRespons(HomeId, 'Stage_09_ZoneStates_data_' + ZoneId, ZonesState_data);
 		ZonesState_data.overlayClearZone = false;
+		ZonesState_data.activateOpenWindow = false;
 		JsonExplorer.TraverseJson(ZonesState_data, HomeId + '.Rooms.' + ZoneId, true, true, 0, 2);
 	}
 

--- a/main.js
+++ b/main.js
@@ -124,8 +124,8 @@ class Tado extends utils.Adapter {
 					} else if (statename == 'activateOpenWindow') {
 						this.log.debug(`Activate Open Window for room '${zone_id}' in home '${home_id}'`);
 						await this.activateOpenWindow(home_id, zone_id);
-					} else if (idSplitted[idSplitted.length - 2] === 'openWindowDetection' && (statename == 'enabled' || statename == 'timeoutInSeconds')) {
-						const openWindowDetectionEnabled = await this.getStateAsync(home_id + '.Rooms.' + zone_id + '.openWindowDetection.enabled');
+					} else if (idSplitted[idSplitted.length - 2] === 'openWindowDetection' && (statename == 'openWindowDetectionEnabled' || statename == 'timeoutInSeconds')) {
+						const openWindowDetectionEnabled = await this.getStateAsync(home_id + '.Rooms.' + zone_id + '.openWindowDetection.openWindowDetectionEnabled');
 						const openWindowDetectionTimeoutInSeconds = await this.getStateAsync(home_id + '.Rooms.' + zone_id + '.openWindowDetection.timeoutInSeconds');
 						let set_openWindowDetectionEnabled = (openWindowDetectionEnabled == null || openWindowDetectionEnabled == undefined || openWindowDetectionEnabled.val == null || openWindowDetectionEnabled.val == '') ? false : openWindowDetectionEnabled.val;
 						let set_openWindowDetectionTimeoutInSeconds = (openWindowDetectionTimeoutInSeconds == null || openWindowDetectionTimeoutInSeconds == undefined || openWindowDetectionTimeoutInSeconds.val == null || openWindowDetectionTimeoutInSeconds.val == '') ? 900 : openWindowDetectionTimeoutInSeconds.val;
@@ -959,6 +959,8 @@ class Tado extends utils.Adapter {
 			ZonesState_data.setting.temperature = {};
 			ZonesState_data.setting.temperature.celsius = null;
 		}
+		ZonesState_data.openWindowDetection.openWindowDetectionEnabled = ZonesState_data.openWindowDetection.enabled;
+		delete ZonesState_data.openWindowDetection.enabled;
 		this.DoWriteJsonRespons(HomeId, 'Stage_09_ZoneStates_data_' + ZoneId, ZonesState_data);
 		ZonesState_data.overlayClearZone = false;
 		ZonesState_data.activateOpenWindow = false;

--- a/main.js
+++ b/main.js
@@ -681,7 +681,7 @@ class Tado extends utils.Adapter {
 	}
 	
 	/**
-	 * Calls the "Active Open Window" endpoint. If the tado thermostate did not detect an open window, the call does nothing.
+	 * Calls the "Active Open Window" endpoint. If the tado thermostat did not detect an open window, the call does nothing.
 	 * @param {string} home_id
 	 * @param {string} zone_id
 	 */

--- a/main.js
+++ b/main.js
@@ -265,9 +265,9 @@ class Tado extends utils.Adapter {
 							
 							case ('activateOpenWindow'):
 								const activateOpenWindow = state;
-								let set_activateOpenWindow = (activateOpenWindow == null || activateOpenWindow == undefined || activateOpenWindow.val == null || activateOpenWindow.val == '') ? 'unknown' : activateOpenWindow.val.toString().toUpperCase();
+								let set_activateOpenWindow = (activateOpenWindow == null || activateOpenWindow == undefined || activateOpenWindow.val == null || activateOpenWindow.val == '') ? 'unknown' : activateOpenWindow.val;
 								if (set_activateOpenWindow !== true) {
-									this.log.debug(`Expecting 'true' as value for 'Activate Open Window'. Got '${JSON.stringify(set_activateOpenWindow)}' (state was '${JSON.stringify(activateOpenWindow)}')`);
+									this.log.debug(`Expecting 'true' as value for 'Activate Open Window'. Got '${JSON.stringify(set_activateOpenWindow)}'`);
 									break;
 								}
 								this.log.debug(`Activate Open Window for room '${zone_id}' in home '${home_id}'`);


### PR DESCRIPTION
This merge requests adds following features

# Child Lock
You can now enable/disable the child lock by setting the `childLockEnabled` property.

# Open Window Detection
You can now modify the settings `tado.[Z].[X].Rooms.[Y].openWindowDetection.enabled` and `tado.[Z].[X].Rooms.[Y].openWindowDetection.timeoutInSeconds`.

Note: I did not change state attribute `write` on `enabled` in the `state_attr.js`, as the parameter is used in other places as well. I guess, you can set it via code nonetheless?

# ActivateOpenWindow
When the thermostat detects an open window, tado will send you a notification and in the app appears a button to power off the radiator/thermostat (for the period defined in `tado.[Z].[X].Rooms.[Y].openWindowDetection.timeoutInSeconds`). The new button `tado.[Z].[X].Rooms.[Y].activateOpenWindow` can trigger this app call. 

Using the button you can create a blockly automation like this:
![image](https://user-images.githubusercontent.com/1216059/150647795-e9eb5cc1-b762-42da-9a5e-313cf10cbf23.png)
This basically is the same the "Auto-Assist" does.

Note that triggering `tado.[Z].[X].Rooms.[Y].activateOpenWindow` without a detected open window by tado has no effect.