### PR TITLE
allow to remove presence Lock again

### DIFF
--- a/lib/state_attr.js
+++ b/lib/state_attr.js
@@ -554,7 +554,8 @@ const state_attrb = {
 		'write': true,
 		'states': {
 			'AWAY': 'Away',
-			'HOME': 'Home'
+			'HOME': 'Home',
+			'AUTO': 'Auto'
 		}
 	},
 	'presenceLocked': {

--- a/main.js
+++ b/main.js
@@ -416,7 +416,7 @@ class Tado extends utils.Adapter {
 	 */
 	async setPresenceLock(home_id, homePresence) {
 		if (!homePresence) homePresence = 'HOME';
-		if (homePresence !== 'HOME' && homePresence !== 'AWAY' !== 'AUTO') {
+		if (homePresence !== 'HOME' && homePresence !== 'AWAY' && homePresence !== 'AUTO') {
 			this.log.error(`Invalid value '${homePresence}' for state 'homePresence'. Allowed values are HOME, AWAY and AUTO.`);
 			return;
 		}

--- a/main.js
+++ b/main.js
@@ -416,8 +416,8 @@ class Tado extends utils.Adapter {
 	 */
 	async setPresenceLock(home_id, homePresence) {
 		if (!homePresence) homePresence = 'HOME';
-		if (homePresence != 'HOME' && homePresence != 'AWAY') {
-			this.log.error(`Invalid value '${homePresence}' for state 'homePresence'. Allowed values are HOME and AWAY.`);
+		if (homePresence !== 'HOME' && homePresence !== 'AWAY' !== 'AUTO') {
+			this.log.error(`Invalid value '${homePresence}' for state 'homePresence'. Allowed values are HOME, AWAY and AUTO.`);
 			return;
 		}
 		const homeState = {
@@ -430,7 +430,11 @@ class Tado extends utils.Adapter {
 			if (await isOnline() == false) {
 				throw new Error('No internet connection detected!');
 			}
-			apiResponse = await this.apiCall(`/api/v2/homes/${home_id}/presenceLock`, 'put', homeState);
+			if (homePresence === 'AUTO') {
+				apiResponse = await this.apiCall(`/api/v2/homes/${home_id}/presenceLock`, 'delete');
+			} else {
+				apiResponse = await this.apiCall(`/api/v2/homes/${home_id}/presenceLock`, 'put', homeState);
+			}
 			this.DoHomeState(home_id);
 			this.log.debug(`API 'state' for home '${home_id}' with body ${JSON.stringify(homeState)} called.`);
 			this.log.debug(`Response from 'presenceLock' is ${JSON.stringify(apiResponse)}`);


### PR DESCRIPTION
Use case:
Switch on Home mode for users without smartphone, if they are detected by some other means and switch back to auto mode, if they are not present (ie people with smartphone and their presence controls heating).